### PR TITLE
Add watchdog reset

### DIFF
--- a/stm32/aioc-fw/Inc/stm32f3xx_hal_conf.h
+++ b/stm32/aioc-fw/Inc/stm32f3xx_hal_conf.h
@@ -67,7 +67,7 @@
 #define HAL_TSC_MODULE_ENABLED
 #define HAL_UART_MODULE_ENABLED
 #define HAL_USART_MODULE_ENABLED
-/* #define HAL_WWDG_MODULE_ENABLED */
+#define HAL_WWDG_MODULE_ENABLED
 
 /* ########################## HSE/HSI Values adaptation ##################### */
 /**

--- a/stm32/aioc-fw/Src/main.c
+++ b/stm32/aioc-fw/Src/main.c
@@ -100,7 +100,7 @@ static void SystemReset(void) {
 #endif
     }
 
-    if (resetFlags & RCC_CSR_IWDGRSTF) {
+    if (resetFlags & RCC_CSR_WWDGRSTF) {
 #if defined(SYSTEM_MEMORY_BASE)
         /* Reset cause was watchdog, which is used for rebooting into the bootloader.
            Set stack pointer to *SYSTEM_MEMORY_BASE
@@ -189,6 +189,17 @@ int main(void)
 
     USB_Init();
 
+    /* Enable indepedent watchdog to reset on lockup*/
+    IWDG_HandleTypeDef IWDGHandle = {
+        .Instance = IWDG,
+        .Init = {
+            .Prescaler = IWDG_PRESCALER_8,
+            .Reload = 0x0FFF,
+            .Window = 0x0FFF
+        }
+    };
+    HAL_IWDG_Init(&IWDGHandle);
+
     uint32_t i = 0;
     while (1) {
         USB_Task();
@@ -206,6 +217,8 @@ int main(void)
                     fb.feedbackMin, fb.feedbackMax, fb.feedbackAvg);
 #endif
         }
+
+        HAL_IWDG_Refresh(&IWDGHandle);
     }
 
   return 0;

--- a/stm32/aioc-fw/Src/usb_dfu.c
+++ b/stm32/aioc-fw/Src/usb_dfu.c
@@ -7,15 +7,17 @@ void tud_dfu_runtime_reboot_to_dfu_cb(void)
 {
     /* Use the watchdog timer for a timed reset. This assures
      * the host can close the open pipe before the device reboots. */
+    __HAL_RCC_WWDG_CLK_ENABLE();
 
-    IWDG_HandleTypeDef IWDGHandle = {
-        .Instance = IWDG,
+    WWDG_HandleTypeDef WWDGHandle = {
+        .Instance = WWDG,
         .Init = {
-            .Prescaler = IWDG_PRESCALER_4,
-            .Reload = 128,
-            .Window = 0x0FFF
+            .Prescaler = WWDG_PRESCALER_1,
+            .Window = 0x7F,
+			.Counter = 0x50,
+			.EWIMode = WWDG_EWI_DISABLE
         }
     };
 
-    HAL_IWDG_Init(&IWDGHandle);
+    HAL_WWDG_Init(&WWDGHandle);
 }


### PR DESCRIPTION
Use the independent watchdog reset to reset the AIOC if there are any failures or lockups. It is currently configured for a 1s timeout. Useful for remote deployments.
This changes the DFU watchdog to the window watchdog instead.